### PR TITLE
UpgradeTo5.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:5.4.0
+FROM docker.elastic.co/elasticsearch/elasticsearch:5.5.1
 
 # https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html
 


### PR DESCRIPTION
We need to upgrade to V5 of ElasticSearch to get some more functionality in Nest.